### PR TITLE
Add config validation and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 17, 21 ]
     name: Java ${{ matrix.java }} build
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ This is a [Spring Cloud](https://spring.io/projects/spring-cloud) Starter for th
 Just provide the right properties as defined below and the appropriate [AWSCredentialsProvider](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/AWSCredentialsProvider.html) object will be activated for injection into your Spring objects. An example for the creation of [BasicAwsCredentials](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/BasicAWSCredentials.html) is shown below. You can follow the link below to understand all the other supported credential models. 
 
 ```properties
-# For BasicAwsCredentialsConfig
+# for BasicAwsCredentials
 spring.cloud.aws.credentials.access-key=YOUR_ACCESS_KEY
 spring.cloud.aws.credentials.secret-key=YOUR_SECRET_KEY
+
+# an optional method to do the same
 spring.cloud.aws.credentials.profile.name=YOUR_PROFILE
 spring.cloud.aws.credentials.profile.path=~/.aws/credentials
 ```
@@ -24,10 +26,7 @@ spring.cloud.aws.credentials.profile.path=~/.aws/credentials
 
 ```properties
 aws.bedrock.model.id=anthropic.claude-v2
-aws.bedrock.model.claude.prompt=defaultPrompt
 aws.bedrock.model.claude.temperature=0.5
-aws.bedrock.model.claude.topP=0.5
-aws.bedrock.model.claude.topK=50
 aws.bedrock.model.claude.maxTokensToSample=100
 ```
 
@@ -47,17 +46,13 @@ One can use the activated clients to interact with the AWS Bedrock service based
 
 The best part of the Starter is the activation of a service object which has the `invoke` method.
 
-All you need to do is provide the properties like one one of the sets below to activate the appropriate implementations of the BedrockService Interface ( Claude, Jurasic or Llama).
+All you need to do is provide the properties like one of the sets below to activate the appropriate implementations of the BedrockService Interface ( Claude, Jurasic or Llama).
 
 #### Claude model parameters
 
 ```properties
 aws.bedrock.model.id=anthropic.claude-v2
-
-aws.bedrock.model.claude.prompt=defaultPrompt
 aws.bedrock.model.claude.temperature=0.5
-aws.bedrock.model.claude.topP=0.5
-aws.bedrock.model.claude.topK=50
 aws.bedrock.model.claude.maxTokensToSample=100
 ```
 
@@ -65,8 +60,6 @@ aws.bedrock.model.claude.maxTokensToSample=100
 
 ```properties 
 aws.bedrock.model.id=ai21.j2-mid-v1
-
-aws.bedrock.model.jurassic.prompt=Your prompt here
 aws.bedrock.model.jurassic.maxTokens=200
 aws.bedrock.model.jurassic.temperature=0.5
 ```
@@ -75,8 +68,6 @@ aws.bedrock.model.jurassic.temperature=0.5
 
 ```properties
 aws.bedrock.model.id=anthropic.llama2-v1
-
-aws.bedrock.model.llama2.prompt=Your prompt here
 aws.bedrock.model.llama2.maxTokens=200
 aws.bedrock.model.llama2.temperature=0.5
 ```
@@ -86,19 +77,29 @@ aws.bedrock.model.llama2.temperature=0.5
 Once activated, the Service can be autowired and used as below.
 
 ```java
-private final ClaudeService claudeService;
+@RestController
+public class ClaudeController {
 
-@Autowired
-public ClaudeController(ClaudeService claudeService) {
-    this.claudeService = claudeService;
-}
+    private final ClaudeService claudeService;
 
-@GetMapping("/invoke")
-public String invokeClaude(@RequestParam String prompt) {
-    try {
-        return claudeService.invokeClaude(prompt);
-    } catch (Exception e) {
-        return "Error invoking Claude: " + e.getMessage();
+    @Autowired
+    public ClaudeController(ClaudeService claudeService) {
+        this.claudeService = claudeService;
+    }
+
+    @GetMapping("/invoke")
+    public String invoke(@RequestParam String prompt) {
+        try {
+            return claudeService.invoke(prompt);
+        } catch (Exception e) {
+            return "Error invoking Claude: " + e.getMessage();
+        }
     }
 }
+```
+
+You might also want to take a look at and/or run the Service [tests](src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl).  To do that, make sure you've set the appropriate `AWS_*` environment variables, then execute
+
+```bash
+mvn test -Dspring.profiles.active=authorized
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/ClaudeConfig.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/ClaudeConfig.java
@@ -3,13 +3,14 @@ package io.clue2solve.aws.bedrock.springboot.starter.autoconfigure.aimodels;
 import io.clue2solve.aws.bedrock.springboot.starter.config.ClaudeProperties;
 import io.clue2solve.aws.bedrock.springboot.starter.service.BedrockService;
 import io.clue2solve.aws.bedrock.springboot.starter.service.impl.ClaudeService;
+import org.springframework.context.annotation.Conditional;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnProperty(name = "aws.bedrock.model.id", havingValue = "anthropic.claude-v2")
+@Conditional(OnClaude.class)
 public class ClaudeConfig {
 
 	@Bean

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/JurassicConfig.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/JurassicConfig.java
@@ -3,13 +3,14 @@ package io.clue2solve.aws.bedrock.springboot.starter.autoconfigure.aimodels;
 import io.clue2solve.aws.bedrock.springboot.starter.config.JurassicProperties;
 import io.clue2solve.aws.bedrock.springboot.starter.service.BedrockService;
 import io.clue2solve.aws.bedrock.springboot.starter.service.impl.JurassicService;
+import org.springframework.context.annotation.Conditional;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnProperty(name = "aws.bedrock.model.id", havingValue = "ai21.j2-mid-v1")
+@Conditional(OnJurassic.class)
 public class JurassicConfig {
 
 	@Bean

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/LlamaConfig.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/LlamaConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnProperty(name = "aws.bedrock.model.id", havingValue = "meta.llama2-13b-chat-v1")
+@ConditionalOnProperty(name = "aws.bedrock.model.llama.id", havingValue = "meta.llama2-13b-chat-v1")
 public class LlamaConfig {
 
 	@Bean

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/OnClaude.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/OnClaude.java
@@ -1,0 +1,27 @@
+package io.clue2solve.aws.bedrock.springboot.starter.autoconfigure.aimodels;
+
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+class OnClaude extends AnyNestedCondition {
+
+	OnClaude() {
+		super(ConfigurationPhase.PARSE_CONFIGURATION);
+	}
+
+	@ConditionalOnProperty(name = "aws.bedrock.model.claude.id", havingValue = "anthropic.claude-v2")
+	static class OnClaudeV2 {
+
+	}
+
+	@ConditionalOnProperty(name = "aws.bedrock.model.claude.id", havingValue = "anthropic.claude-v1")
+	static class OnClaudeV1 {
+
+	}
+
+	@ConditionalOnProperty(name = "aws.bedrock.model.claude.id", havingValue = "anthropic.claude-instant-v1")
+	static class OnClaudeInstantV1 {
+
+	}
+
+}

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/OnJurassic.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/aimodels/OnJurassic.java
@@ -1,0 +1,42 @@
+package io.clue2solve.aws.bedrock.springboot.starter.autoconfigure.aimodels;
+
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+class OnJurassic extends AnyNestedCondition {
+
+	OnJurassic() {
+		super(ConfigurationPhase.PARSE_CONFIGURATION);
+	}
+
+	@ConditionalOnProperty(name = "aws.bedrock.model.jurassic.id", havingValue = "ai21.j2-grande-instruct")
+	static class OnJurassic2GrandeInstruct {
+
+	}
+
+	@ConditionalOnProperty(name = "aws.bedrock.model.jurassic.id", havingValue = "ai21.j2-jumbo-instruct")
+	static class OnJurassic2JumboInstruct {
+
+	}
+
+	@ConditionalOnProperty(name = "aws.bedrock.model.jurassic.id", havingValue = "ai21.j2-mid")
+	static class OnJurassic2Mid {
+
+	}
+
+	@ConditionalOnProperty(name = "aws.bedrock.model.jurassic.id", havingValue = "ai21.j2-mid-v1")
+	static class OnJurassic2MidV1 {
+
+	}
+
+	@ConditionalOnProperty(name = "aws.bedrock.model.jurassic.id", havingValue = "ai21.j2-ultra")
+	static class OnCJurassic2Ultra {
+
+	}
+
+	@ConditionalOnProperty(name = "aws.bedrock.model.jurassic.idd", havingValue = "ai21.j2-ultra-v1")
+	static class OnCJurassic2UltraV1 {
+
+	}
+
+}

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/clients/BedrockClientConfig.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/autoconfigure/clients/BedrockClientConfig.java
@@ -53,7 +53,7 @@ public class BedrockClientConfig {
 	public BedrockAsyncClient bedrockAsyncClient() {
 		return BedrockAsyncClient.builder()
 			.region(Region.of(region))
-			.credentialsProvider((AwsCredentialsProvider) awsCredentialsProvider)
+			.credentialsProvider(awsCredentialsProvider)
 			.build();
 	}
 

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/config/ClaudeProperties.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/config/ClaudeProperties.java
@@ -1,14 +1,29 @@
 package io.clue2solve.aws.bedrock.springboot.starter.config;
 
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.*;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+@Validated
 @ConfigurationProperties(prefix = "aws.bedrock.model.claude")
-public record ClaudeProperties(String modelId, String prompt, double temperature, double topP, int topK,
-		int maxTokensToSample, List<String> stopSequences) {
-	public ClaudeProperties() {
-		this("anthropic.claude-v2", "defaultPrompt", 0.5, 0.5, 50, 100, Collections.emptyList());
+public record ClaudeProperties(
+		@Pattern(regexp = "anthropic.claude-instant-v1|anthropic.claude-v1|anthropic.claude-v2") String id,
+		@Nullable String prePrompt, @Nullable String postPrompt,
+		@DecimalMin("0.1") @DecimalMax("1.0") Double temperature, @Min(1) @Max(100000) Integer maxTokens,
+		@Nullable List<String> stopSequences) {
+
+	public ClaudeProperties(String id, String prePrompt, String postPrompt, Double temperature, Integer maxTokens,
+			List<String> stopSequences) {
+		this.id = Optional.ofNullable(id).orElse("anthropic.claude-v2");
+		this.prePrompt = Optional.ofNullable(prePrompt).orElse("Human: ");
+		this.postPrompt = Optional.ofNullable(postPrompt).orElse("Assistant: ");
+		this.temperature = Optional.ofNullable(temperature).orElse(0.5);
+		this.maxTokens = Optional.ofNullable(maxTokens).orElse(100);
+		this.stopSequences = Optional.ofNullable(stopSequences).orElse(Collections.emptyList());
 	}
 }

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/config/JurassicProperties.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/config/JurassicProperties.java
@@ -1,15 +1,30 @@
 package io.clue2solve.aws.bedrock.springboot.starter.config;
 
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.*;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.Optional;
 
 /**
- * Sample perperties aws.bedrock.model.jurassic.modelId=ai21.j2-mid-v1
+ * Sample properties aws.bedrock.model.jurassic.modelId=ai21.j2-mid-v1
  * aws.bedrock.model.jurassic.prompt=Human: Assistant:
  * aws.bedrock.model.jurassic.maxTokens=200 aws.bedrock.model.jurassic.temperature=0.5
+ *
+ * @ see https://docs.ai21.com/reference/j2-complete-api-ref
  */
+@Validated
 @ConfigurationProperties(prefix = "aws.bedrock.model.jurassic")
-public record JurassicProperties(String modelId, String prompt, int maxTokens, double temperature) {
-	public JurassicProperties() {
-		this("ai21.j2-mid-v1", "Human: Assistant:", 200, 0.5);
+public record JurassicProperties(@Pattern(
+		regexp = "ai21.j2-grande-instruct|ai21.j2-jumbo-instruct|ai21.j2-mid|ai21.j2-mid-v1|ai21.j2-ultra|ai21.j2-ultra-v1") String id,
+		@Nullable String prePrompt, @Min(1) @Max(8192) Integer maxTokens,
+		@DecimalMin("0.1") @DecimalMax("1.0") Double temperature) {
+
+	public JurassicProperties(String id, String prePrompt, Integer maxTokens, Double temperature) {
+		this.id = Optional.ofNullable(id).orElse("ai21.j2-mid-v1");
+		this.prePrompt = Optional.ofNullable(prePrompt).orElse("Human: ");
+		this.temperature = Optional.ofNullable(temperature).orElse(0.5);
+		this.maxTokens = Optional.ofNullable(maxTokens).orElse(200);
 	}
 }

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/config/LlamaProperties.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/config/LlamaProperties.java
@@ -1,13 +1,24 @@
 package io.clue2solve.aws.bedrock.springboot.starter.config;
 
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.*;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+@Validated
 @ConfigurationProperties(prefix = "aws.bedrock.model.llama")
-public record LlamaProperties(String modelId, String prompt, double temperature, int maxTokens,
-		List<String> stopSequences) {
-	public LlamaProperties() {
-		this("meta.llama2-13b-chat-v1", "defaultPrompt", 0.5, 100, List.of("Human:"));
+public record LlamaProperties(@Pattern(regexp = "meta.llama2-13b-chat-v1") String id,
+		@DecimalMin("0.1") @DecimalMax("1.0") Double topP, @DecimalMin("0.1") @DecimalMax("1.0") Double temperature,
+		@Min(1) @Max(4000) Integer maxTokens) {
+
+	public LlamaProperties(String id, Double topP, Double temperature, Integer maxTokens) {
+		this.id = Optional.ofNullable(id).orElse("meta.llama2-13b-chat-v1");
+		this.temperature = Optional.ofNullable(temperature).orElse(0.5);
+		this.topP = Optional.ofNullable(topP).orElse(0.9);
+		this.maxTokens = Optional.ofNullable(maxTokens).orElse(100);
 	}
 }

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/JurassicService.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/JurassicService.java
@@ -3,15 +3,18 @@ package io.clue2solve.aws.bedrock.springboot.starter.service.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.clue2solve.aws.bedrock.springboot.starter.config.JurassicProperties;
 import io.clue2solve.aws.bedrock.springboot.starter.service.BedrockService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
-import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class JurassicService implements BedrockService {
+
+	private static final Logger log = LoggerFactory.getLogger(JurassicService.class);
 
 	private final BedrockRuntimeClient client;
 
@@ -20,6 +23,7 @@ public class JurassicService implements BedrockService {
 	public JurassicService(BedrockRuntimeClient client, JurassicProperties properties) {
 		this.client = client;
 		this.properties = properties;
+		log.info("Instantiating JurassicService");
 	}
 
 	@Override
@@ -27,23 +31,22 @@ public class JurassicService implements BedrockService {
 		try {
 			var mapper = new ObjectMapper();
 			var payload = mapper.createObjectNode();
-			payload.put("prompt", properties.prompt() + prompt);
+			payload.put("prompt", String.format("%s%n%s", properties.prePrompt(), prompt));
 			payload.put("maxTokens", properties.maxTokens());
 			payload.put("temperature", properties.temperature());
 
 			var body = SdkBytes.fromUtf8String(payload.toString());
 
-			var request = InvokeModelRequest.builder().modelId(properties.modelId()).body(body).build();
+			var request = InvokeModelRequest.builder().modelId(properties.id()).body(body).build();
 
 			var response = client.invokeModel(request);
 
-			var responseBody = new ObjectMapper().readValue(response.body().asUtf8String(), ObjectNode.class);
+			var responseBody = mapper.readValue(response.body().asUtf8String(), ObjectNode.class);
 
 			return responseBody.get("completions").elements().next().get("data").get("text").asText();
 		}
-		catch (AwsServiceException e) {
-			System.err.println(e.awsErrorDetails().errorMessage());
-			System.exit(1);
+		catch (AwsServiceException ase) {
+			log.error("Failed to obtain result from JurassicService", ase);
 		}
 		return null;
 	}

--- a/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/LlamaService.java
+++ b/src/main/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/LlamaService.java
@@ -5,13 +5,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.clue2solve.aws.bedrock.springboot.starter.config.LlamaProperties;
 import io.clue2solve.aws.bedrock.springboot.starter.service.BedrockService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
-import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 
 public class LlamaService implements BedrockService {
+
+	private static final Logger log = LoggerFactory.getLogger(LlamaService.class);
 
 	private final BedrockRuntimeClient client;
 
@@ -20,6 +23,7 @@ public class LlamaService implements BedrockService {
 	public LlamaService(BedrockRuntimeClient client, LlamaProperties properties) {
 		this.client = client;
 		this.properties = properties;
+		log.info("Instantiating LlamaService");
 	}
 
 	@Override
@@ -27,27 +31,25 @@ public class LlamaService implements BedrockService {
 		try {
 			var mapper = new ObjectMapper();
 			var payload = mapper.createObjectNode();
-			payload.put("prompt", properties.prompt() + prompt);
-			payload.put("maxTokens", properties.maxTokens());
+			payload.put("prompt", prompt);
+			payload.put("max_gen_len", properties.maxTokens());
+			payload.put("top_p", properties.topP());
 			payload.put("temperature", properties.temperature());
 
 			var body = SdkBytes.fromUtf8String(payload.toString());
 
-			var request = InvokeModelRequest.builder().modelId(properties.modelId()).body(body).build();
+			var request = InvokeModelRequest.builder().modelId(properties.id()).body(body).build();
 
 			var response = client.invokeModel(request);
 
-			var responseBody = new ObjectMapper().readValue(response.body().asUtf8String(), ObjectNode.class);
+			var responseBody = mapper.readValue(response.body().asUtf8String(), ObjectNode.class);
 
-			return responseBody.get("completions").elements().next().get("data").get("text").asText();
+			return responseBody.get("generation").asText();
 		}
-		catch (AwsServiceException e) {
-			System.err.println(e.awsErrorDetails().errorMessage());
-			System.exit(1);
+		catch (AwsServiceException ase) {
+			log.error("Failed to obtain result from LlamaService", ase);
 		}
 		return null;
 	}
-
-	// Add methods to interact with the llama model here
 
 }

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/TestInit.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/TestInit.java
@@ -1,0 +1,10 @@
+package io.clue2solve.aws.bedrock.springboot.starter;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+public class TestInit {
+
+}

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/ClaudeServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/ClaudeServiceTest.java
@@ -20,8 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 @TestPropertySource(properties = { "aws.region=us-west-2", "aws.bedrock.model.claude.id=anthropic.claude-v2" })
 @EnabledIf(
-		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}",
-		loadContext = true)
+		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}")
 @DisabledIf(
 		expression = "#{!environment.containsProperty('AWS_ACCESS_KEY_ID') || !environment.containsProperty('AWS_SECRET_ACCESS_KEY')}",
 		reason = "Must have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables defined to execute this test!")

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/ClaudeServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/ClaudeServiceTest.java
@@ -1,0 +1,43 @@
+package io.clue2solve.aws.bedrock.springboot.starter.service.impl;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.IfProfileValue;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@TestPropertySource(properties = { "aws.region=us-west-2", "aws.bedrock.model.claude.id=anthropic.claude-v2" })
+@EnabledIf(
+		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}",
+		loadContext = true)
+class ClaudeServiceTest {
+
+	private final static Logger log = LoggerFactory.getLogger(ClaudeServiceTest.class);
+
+	@Autowired
+	private ClaudeService service;
+
+	@Test
+	void invokeHappyPath() {
+		try {
+			String response = service.invoke(
+					"Please compare and contrast the qualities and characteristics of a Bengal tiger with a snow leopard");
+			Assertions.assertNotNull(response);
+			log.info(response);
+		}
+		catch (JsonProcessingException jpe) {
+			fail("Couldn't process request");
+		}
+	}
+
+}

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/ClaudeServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/ClaudeServiceTest.java
@@ -1,5 +1,7 @@
 package io.clue2solve.aws.bedrock.springboot.starter.service.impl;
 
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
@@ -8,10 +10,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.IfProfileValue;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.DisabledIf;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,6 +25,9 @@ import static org.junit.jupiter.api.Assertions.*;
 @EnabledIf(
 		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}",
 		loadContext = true)
+@DisabledIf(
+		expression = "#{!environment.containsProperty('AWS_ACCESS_KEY_ID') || !environment.containsProperty('AWS_SECRET_ACCESS_KEY')}",
+		reason = "Must have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables defined to execute this test!")
 class ClaudeServiceTest {
 
 	private final static Logger log = LoggerFactory.getLogger(ClaudeServiceTest.class);

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/ClaudeServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/ClaudeServiceTest.java
@@ -1,7 +1,5 @@
 package io.clue2solve.aws.bedrock.springboot.starter.service.impl;
 
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
@@ -10,13 +8,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.IfProfileValue;
+
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.DisabledIf;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/JurassicServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/JurassicServiceTest.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.DisabledIf;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -17,6 +18,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 @EnabledIf(
 		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}",
 		loadContext = true)
+@DisabledIf(
+		expression = "#{!environment.containsProperty('AWS_ACCESS_KEY_ID') || !environment.containsProperty('AWS_SECRET_ACCESS_KEY')}",
+		reason = "Must have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables defined to execute this test!")
 class JurassicServiceTest {
 
 	private final static Logger log = LoggerFactory.getLogger(JurassicServiceTest.class);

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/JurassicServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/JurassicServiceTest.java
@@ -1,0 +1,40 @@
+package io.clue2solve.aws.bedrock.springboot.starter.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SpringBootTest
+@TestPropertySource(properties = { "aws.region=us-west-2", "aws.bedrock.model.jurassic.id=ai21.j2-mid-v1" })
+@EnabledIf(
+		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}",
+		loadContext = true)
+class JurassicServiceTest {
+
+	private final static Logger log = LoggerFactory.getLogger(JurassicServiceTest.class);
+
+	@Autowired
+	private JurassicService service;
+
+	@Test
+	void invokeHappyPath() {
+		try {
+			String response = service.invoke(
+					"Commentate in a dark, sinister but humourous way a hypothetical 3 round fighting match between two DC Comics characters Superman and Darkside");
+			Assertions.assertNotNull(response);
+			log.info(response);
+		}
+		catch (JsonProcessingException jpe) {
+			fail("Couldn't process request");
+		}
+	}
+
+}

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/JurassicServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/JurassicServiceTest.java
@@ -16,8 +16,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @SpringBootTest
 @TestPropertySource(properties = { "aws.region=us-west-2", "aws.bedrock.model.jurassic.id=ai21.j2-mid-v1" })
 @EnabledIf(
-		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}",
-		loadContext = true)
+		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}")
 @DisabledIf(
 		expression = "#{!environment.containsProperty('AWS_ACCESS_KEY_ID') || !environment.containsProperty('AWS_SECRET_ACCESS_KEY')}",
 		reason = "Must have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables defined to execute this test!")

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/LlamaServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/LlamaServiceTest.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.DisabledIf;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -17,6 +18,9 @@ import static org.junit.jupiter.api.Assertions.fail;
 @EnabledIf(
 		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}",
 		loadContext = true)
+@DisabledIf(
+		expression = "#{!environment.containsProperty('AWS_ACCESS_KEY_ID') || !environment.containsProperty('AWS_SECRET_ACCESS_KEY')}",
+		reason = "Must have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables defined to execute this test!")
 class LlamaServiceTest {
 
 	private final static Logger log = LoggerFactory.getLogger(LlamaServiceTest.class);

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/LlamaServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/LlamaServiceTest.java
@@ -16,8 +16,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @SpringBootTest
 @TestPropertySource(properties = { "aws.region=us-west-2", "aws.bedrock.model.llama.id=meta.llama2-13b-chat-v1" })
 @EnabledIf(
-		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}",
-		loadContext = true)
+		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}")
 @DisabledIf(
 		expression = "#{!environment.containsProperty('AWS_ACCESS_KEY_ID') || !environment.containsProperty('AWS_SECRET_ACCESS_KEY')}",
 		reason = "Must have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables defined to execute this test!")

--- a/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/LlamaServiceTest.java
+++ b/src/test/java/io/clue2solve/aws/bedrock/springboot/starter/service/impl/LlamaServiceTest.java
@@ -1,0 +1,40 @@
+package io.clue2solve.aws.bedrock.springboot.starter.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SpringBootTest
+@TestPropertySource(properties = { "aws.region=us-west-2", "aws.bedrock.model.llama.id=meta.llama2-13b-chat-v1" })
+@EnabledIf(
+		expression = "#{environment.getActiveProfiles().length > 0 && {'authorized'}.contains(environment.getActiveProfiles()[0])}",
+		loadContext = true)
+class LlamaServiceTest {
+
+	private final static Logger log = LoggerFactory.getLogger(LlamaServiceTest.class);
+
+	@Autowired
+	private LlamaService service;
+
+	@Test
+	void invokeHappyPath() {
+		try {
+			String response = service.invoke(
+					"Please list the Heisman Trophy winners (name, age, university attended, and year each individual won the award) for the years between 1980 and present in ascending order (by year).");
+			Assertions.assertNotNull(response);
+			log.info(response);
+		}
+		catch (JsonProcessingException jpe) {
+			fail("Couldn't process request");
+		}
+	}
+
+}


### PR DESCRIPTION
* Use spring-boot-validation-starter to be able to apply validation constraints on configuration properties
* Cleanup unused imports
* Apply consistent property names; remove redundant config
* Add Logger to all service impl; don't exit immediately, rather log on caught exceptions
* Reuse ObjectMapper local var in service method impls
* Fix incorrect service impl for returning response in LlamaService
* Add integration tests for each service implementation (only activated when conditions met and Spring profile activated
* Update README documentation; prune the number of required config params to activate a service implementation