### PR TITLE
Fix CI and update SNAPSHOT version format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: ./mvnw clean install
+        run: ./mvnw clean install -Dgpg.skip

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>io.clue2solve</groupId>
     <artifactId>spring-cloud-aws-bedrock-starter</artifactId>
-    <version>0.0.2.SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>spring-cloud-aws-bedrock-starter</name>
     <description>Spring Cloud Starter for AWS Bedrock</description>
     <properties>


### PR DESCRIPTION
* Maven was complaining about the version format. That's fixed now.
* Don't sign artifacts on CI runs, so use the skip flag.
